### PR TITLE
Revert "Small bug fixed"

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3,8 +3,7 @@
 * {
   margin: 0;
   padding: 0;
-}
-
+  
  h1 {
   font-family: 'Amiga Forever', sans-serif;
   text-align: center;
@@ -21,10 +20,9 @@ p {
   font-size: small;
 }
 
-.card-back h3,
-.card-back p {
+h3,
+p {
   padding: 15px;
-  color: black;
 }
 
 img {
@@ -95,6 +93,8 @@ body {
 
 .card-back {
   background-color: #73ca75;
+  /* background-color: #DFACDE; */
+  color: azure;
   transform: rotateY(180deg);
 }
 


### PR DESCRIPTION
The Kaboom container has gone off centre. I'm not sure if this is because of a CSS conflict or because of something that @todorr92  has implemented. There's a few more of those letters on the side and portrait view is too big for the viewer.

Reverts liamthetate/hackathon#38